### PR TITLE
Add metadata_expire=0 to yum configuration

### DIFF
--- a/docs/guide-repo-config.md
+++ b/docs/guide-repo-config.md
@@ -44,6 +44,7 @@ sudo tee /etc/yum.repos.d/neuron.repo > /dev/null <<EOF
 name=Neuron YUM Repository
 baseurl=https://yum.repos.neuron.amazonaws.com
 enabled=1
+metadata_expire=0
 EOF
 
 sudo rpm --import https://yum.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB


### PR DESCRIPTION
Add metadata_expire=0 so that customers do not suffer 4xx errors due to yum cache effects when new package versions are published.

*Issue #, if available:*

*Description of changes:*
Add 'metadata_expire=0' to yum repo configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
