### PR TITLE
Correct a typo of the inf1 instance type

### DIFF
--- a/src/k8/k8s-neuron-device-plugin.yml
+++ b/src/k8/k8s-neuron-device-plugin.yml
@@ -40,7 +40,7 @@ spec:
                       - inf1.xlarge
                       - inf1.2xlarge
                       - inf1.6xlarge
-                      - inf1.4xlarge
+                      - inf1.24xlarge
               - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In


### PR DESCRIPTION
inf1.4xlarge should be inf1.24xlarge

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
