### PR TITLE
Dynamic batching is also supported in Pytorch Neuron

### DIFF
--- a/neuron-guide/appnotes/perf/performance-tuning.rst
+++ b/neuron-guide/appnotes/perf/performance-tuning.rst
@@ -110,8 +110,7 @@ CPU threads to feed inputs into the Neuron pipeline. The number of
 threads need to be larger than the specified maximum number of
 NeuronCores.
 
-Additionally, dynamic batching (framework optimization currently
-supported only by TensorFlow-Neuron) can be used to process a larger
+Additionally, dynamic batching can be used to process a larger
 client-side inference batch-size and the framework automatically breaks
 up the user-batch into smaller batch sizes to match the compiled
 batch-size. This technique increases the achievable throughput by hiding


### PR DESCRIPTION
Update on the documentation as dynamic batching is available on Pytorch too.

*Issue #, if available:*

*Description of changes:*
Update on the documentation to remove the line about dynamic batch being supported only in Tensorflow_Neuron.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
