### PR TITLE
Fix inf1 device memory values (8GB per chip)

### DIFF
--- a/general/arch/neuron-hardware/inf1-arch.rst
+++ b/general/arch/neuron-hardware/inf1-arch.rst
@@ -55,7 +55,7 @@ customers to choose between four instances sizes:
         - 16
         - 64
         - 128
-        - 16
+        - 8
         - 50
         - N/A
         - up-to 25
@@ -66,7 +66,7 @@ customers to choose between four instances sizes:
         - 48
         - 256
         - 512
-        - 48
+        - 32
         - 200
         - 32
         - 25
@@ -77,7 +77,7 @@ customers to choose between four instances sizes:
         - 192
         - 1024
         - 2048
-        - 192
+        - 128
         - 800
         - 32
         - 100


### PR DESCRIPTION
The inf1 arch doc page has wrong values for device memory column (looks like a copy of the host memory values). For example inf1.2xlarge should have 8GB of device memory (single inf1 chip) instead of 16GB.

Also verified by testing:
[data/instance-type](http://169.254.169.254/latest/meta-data/instance-type) % Total % Received % Xferd Average Speed Time Time Time Current Dload Upload Total Spent Left Speed
100 12 100 12 0 0 12000 0 --:--:-- --:--:-- --:--:-- 12000 inf1.2xlarge

ubuntu@ip-172-31-29-117:~$ neuron-ls
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON | PCI |
| DEVICE | CORES | MEMORY | BDF |
+--------+--------+--------+---------+
| 0 | 4 | 8 GB | 00:1f.0 |
+--------+--------+--------+---------+`