### PR TITLE
change parallelcluster devflow link to main neuron sample branch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/general/devflows/training/parallelcluster/parallelcluster-training.rst
+++ b/general/devflows/training/parallelcluster/parallelcluster-training.rst
@@ -37,7 +37,7 @@ Follow `these setup <https://github.com/aws-neuron/aws-neuron-parallelcluster-sa
 
 2. Create and launch ParallelCluster 
 
-Follow `these creating cluster <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/cluster-configs/trn1-16-nodes-pcluster.md>`_ instructions to launch ParallelCluster in the infrastructure.
+Follow `these creating cluster <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/cluster-configs/trn1-16-nodes-pcluster.md>`_ instructions to launch ParallelCluster in the VPC.
 
 1. Launch training job
 

--- a/general/devflows/training/parallelcluster/parallelcluster-training.rst
+++ b/general/devflows/training/parallelcluster/parallelcluster-training.rst
@@ -32,13 +32,13 @@ Setup environment
 
 1. Install prerequisite infrastructure:
 
-Follow `these setup <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/tree/ga#user-content-prerequisite-infrastructure>`_ instructions to install VPC and all the necessary components for ParallelCluster. 
+Follow `these setup <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/general/network/vpc-subnet-setup.md>`_ instructions to install VPC and all the necessary components for ParallelCluster. 
 
 
 2. Create and launch ParallelCluster 
 
-Follow `these creating cluster <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/tree/ga#user-content-create-a-cluster>`_ instructions to launch ParallelCluster in the infrastructure.
+Follow `these creating cluster <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/cluster-configs/trn1-16-nodes-pcluster.md>`_ instructions to launch ParallelCluster in the infrastructure.
 
 1. Launch training job
 
-Follow `these running training <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/tree/ga#user-content-launch-training-job>`_ instructions to submit a model training script as a slurm job.
+Follow `these running training <https://github.com/aws-neuron/aws-neuron-parallelcluster-samples/blob/master/examples/jobs/dp-bert-launch-job.md>`_ instructions to submit a model training script as a slurm job.


### PR DESCRIPTION
Links in parallelcluster devflow pointed to ga branch of aws neuron samples. Correct it to point to master branch.