### PR TITLE
Remove deprecated annotation scheduler.alpha.kubernetes.io/critical-pod

### DIFF
--- a/src/k8/k8s-neuron-device-plugin.yml
+++ b/src/k8/k8s-neuron-device-plugin.yml
@@ -12,8 +12,9 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+      # Uncomment the annotation below if k8s version is 1.13 or lower
+      # annotations:
+      #   scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: neuron-device-plugin-ds
     spec:


### PR DESCRIPTION
Remove deprecated annotation scheduler.alpha.kubernetes.io/critical-pod Ref: https://github.com/aws-neuron/aws-neuron-sdk/issues/719 
Deprecation of the annotation - https://github.com/kubernetes/kubernetes/pull/70298/files

Testing notes -
```
issue repro
kubectl create -f k.yaml
Warning: spec.template.metadata.annotations[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+; use the "priorityClassName" field instead

with fix
kubectl create -f k.yaml
daemonset.apps/neuron-device-plugin-daemonset1 created

verify priority class
 kubectl get pod neuron-device-plugin-daemonset1-6x6l8 -o yaml -n kube-system | grep priority
  priority: 2000001000
  priorityClassName: system-node-critical



```
