### PR TITLE
remove deprecated node label `beta.kubernetes.io/instance-type`

### DIFF
--- a/src/k8/k8s-neuron-device-plugin.yml
+++ b/src/k8/k8s-neuron-device-plugin.yml
@@ -34,22 +34,6 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
-                  - key: "beta.kubernetes.io/instance-type"
-                    operator: In
-                    values:
-                      - inf1.xlarge
-                      - inf1.2xlarge
-                      - inf1.6xlarge
-                      - inf1.24xlarge
-                      - inf2.xlarge
-                      - inf2.4xlarge
-                      - inf2.8xlarge
-                      - inf2.24xlarge
-                      - inf2.48xlarge
-                      - trn1.2xlarge
-                      - trn1.32xlarge
-                      - trn1n.32xlarge
-              - matchExpressions:
                   - key: "node.kubernetes.io/instance-type"
                     operator: In
                     values:


### PR DESCRIPTION
Fixes #760 

The label has beeb deprecated since Kubernetes 1.17 and Kubernetes version 1.16 has been out of support for over 3 years (04 Aug 2020). 