### PR TITLE
fix: remove redundant namespace of cluster-scoped resource

### DIFF
--- a/src/k8/k8s-neuron-device-plugin-rbac.yml
+++ b/src/k8/k8s-neuron-device-plugin-rbac.yml
@@ -48,7 +48,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: neuron-device-plugin
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
which causes problems if you're validating the YAML e.g. when using kubernetes_manifest terraform resource.


Sorry, this is a tiny change, I haven't the time to read the below in the hope it ain't relevant...

*Description:*

**MANDATORY: PR needs test run output**

**Test Run Output:**
Please specify the release version, instance size and type, OS type and test output.

Training tutorial:
Convergence graph for training tutorials
Performance metrics average_throughput, latency_p50, latency_p99 and MFU% if available


Please make sure this PR contains correct classification terms (Alpha, Beta, and Stable).

If possible, provide your results or a link to them for the reviewer to check your work.


*Issue #, sim, or t.corp if available:*


*Link to RTD for my changes:* 
https://awsdocs-neuron-staging.readthedocs-hosted.com/en/YOUR_BRANCH_NAME/


*Additional context:*





## PR Checklist
- [ ] I've completely filled out the form above!
- [ ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [ ] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ ] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
