### PR TITLE
optimum_neuron sample with sd_15_512

### DIFF
--- a/src/benchmark/pytorch/sd_15_512_optimum_neuron_benchmark.py
+++ b/src/benchmark/pytorch/sd_15_512_optimum_neuron_benchmark.py
@@ -1,0 +1,69 @@
+import os
+os.environ["NEURON_FUSE_SOFTMAX"] = "1"
+import time
+import math
+
+from optimum.neuron import NeuronStableDiffusionPipeline
+
+# Specialized benchmarking class for stable diffusion.
+def benchmark(n_runs, test_name, model, model_inputs):
+    if not isinstance(model_inputs, tuple):
+        model_inputs = (model_inputs,)
+    
+    warmup_run = model(*model_inputs)
+
+    latency_collector = LatencyCollector()
+    # can't use register_forward_pre_hook or register_forward_hook because StableDiffusionPipeline is not a torch.nn.Module
+    
+    for _ in range(n_runs):
+        latency_collector.pre_hook()
+        res = model(*model_inputs)
+        latency_collector.hook()
+    
+    p0_latency_ms = latency_collector.percentile(0) * 1000
+    p50_latency_ms = latency_collector.percentile(50) * 1000
+    p90_latency_ms = latency_collector.percentile(90) * 1000
+    p95_latency_ms = latency_collector.percentile(95) * 1000
+    p99_latency_ms = latency_collector.percentile(99) * 1000
+    p100_latency_ms = latency_collector.percentile(100) * 1000
+
+    report_dict = dict()
+    report_dict["Latency P0"] = f'{p0_latency_ms:.1f}'
+    report_dict["Latency P50"]=f'{p50_latency_ms:.1f}'
+    report_dict["Latency P90"]=f'{p90_latency_ms:.1f}'
+    report_dict["Latency P95"]=f'{p95_latency_ms:.1f}'
+    report_dict["Latency P99"]=f'{p99_latency_ms:.1f}'
+    report_dict["Latency P100"]=f'{p100_latency_ms:.1f}'
+
+    report = f'RESULT FOR {test_name}:'
+    for key, value in report_dict.items():
+        report += f' {key}={value}'
+    print(report)
+
+class LatencyCollector:
+    def __init__(self):
+        self.start = None
+        self.latency_list = []
+
+    def pre_hook(self, *args):
+        self.start = time.time()
+
+    def hook(self, *args):
+        self.latency_list.append(time.time() - self.start)
+
+    def percentile(self, percent):
+        latency_list = self.latency_list
+        pos_float = len(latency_list) * percent / 100
+        max_pos = len(latency_list) - 1
+        pos_floor = min(math.floor(pos_float), max_pos)
+        pos_ceil = min(math.ceil(pos_float), max_pos)
+        latency_list = sorted(latency_list)
+        return latency_list[pos_ceil] if pos_float - pos_floor > 0.5 else latency_list[pos_floor]
+
+# # For saving compiler artifacts
+COMPILER_WORKDIR_ROOT = 'sd_1_5_fp32_512_compile_workdir'
+pipe = NeuronStableDiffusionPipeline.from_pretrained(COMPILER_WORKDIR_ROOT)
+
+prompt = "a photo of an astronaut riding a horse on mars"
+n_runs = 20
+benchmark(n_runs, "stable_diffusion_15_512", pipe, prompt)

--- a/src/benchmark/pytorch/sd_15_512_optimum_neuron_compile.py
+++ b/src/benchmark/pytorch/sd_15_512_optimum_neuron_compile.py
@@ -1,0 +1,23 @@
+import os
+import time
+from optimum.neuron import NeuronStableDiffusionPipeline
+
+# For saving compiler artifacts
+COMPILER_WORKDIR_ROOT = 'sd_1_5_fp32_512_compile_workdir'
+
+# Model ID for SD version pipeline
+model_id = "runwayml/stable-diffusion-v1-5"
+
+# Compilation config
+compiler_args = {"auto_cast": "matmul", "auto_cast_type": "bf16","inline_weights_to_neff": "True"}
+input_shapes = {"batch_size": 1, "height": 512, "width": 512}
+
+# --- Compile the model
+start_time = time.time()
+stable_diffusion = NeuronStableDiffusionPipeline.from_pretrained(model_id, export=True, **compiler_args, **input_shapes)
+
+# Save the compiled model
+stable_diffusion.save_pretrained(COMPILER_WORKDIR_ROOT)
+
+compile_time = time.time() - start_time
+print('Total compile time:', compile_time)


### PR DESCRIPTION
*Description:*
optimum_neuron sample with sd_15_512

**MANDATORY: PR needs test run output**

**Test Run Output:**
Please specify the release version, instance size and type, OS type and test output.

```
root@sd2-compile-optimum-neuron-87fk8:/# uname -a
Linux sd2-compile-optimum-neuron-87fk8 5.10.213-201.855.amzn2.x86_64 #1 SMP Mon Mar 25 18:16:11 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
root@sd2-compile-optimum-neuron-87fk8:/# pip list
Package                       Version
----------------------------- -------------------
absl-py                       2.1.0
accelerate                    0.23.0
aiofiles                      23.2.1
aiohttp                       3.9.5
aiosignal                     1.3.1
altair                        5.3.0
annotated-types               0.6.0
anyio                         4.3.0
asttokens                     2.4.1
async-timeout                 4.0.3
attrs                         23.2.0
aws-neuronx-runtime-discovery 2.9
awscli                        1.32.94
boto3                         1.28.60
botocore                      1.34.94
Brotli                        1.1.0
cached-property               1.5.2
cachetools                    5.3.3
certifi                       2024.2.2
cffi                          1.16.0
charset-normalizer            3.3.2
click                         8.1.7
cloud-tpu-client              0.10
colorama                      0.4.4
coloredlogs                   15.0.1
conda                         23.1.0
conda-content-trust           0.2.0
conda-package-handling        2.2.0
conda_package_streaming       0.9.0
contourpy                     1.2.1
cryptography                  42.0.5
cycler                        0.12.1
Cython                        3.0.8
datasets                      2.19.0
decorator                     5.1.1
diffusers                     0.27.2
dill                          0.3.8
docutils                      0.16
ec2-metadata                  2.10.0
enum-compat                   0.0.3
exceptiongroup                1.2.0
executing                     2.0.1
fastapi                       0.110.3
ffmpy                         0.3.2
filelock                      3.13.1
fonttools                     4.51.0
frozenlist                    1.4.1
fsspec                        2024.2.0
google-api-core               1.34.1
google-api-python-client      1.8.0
google-auth                   2.28.1
google-auth-httplib2          0.2.0
googleapis-common-protos      1.62.0
gradio                        4.28.3
gradio_client                 0.16.0
h11                           0.14.0
h5py                          3.10.0
httpcore                      1.0.5
httplib2                      0.22.0
httptools                     0.6.1
httpx                         0.27.0
huggingface-hub               0.22.2
humanfriendly                 10.0
idna                          3.6
importlib_metadata            7.1.0
importlib_resources           6.4.0
ipython                       8.22.1
islpy                         2023.1
jedi                          0.19.1
Jinja2                        3.1.3
jmespath                      1.0.1
joblib                        1.3.2
jsonschema                    4.21.1
jsonschema-specifications     2023.12.1
kiwisolver                    1.4.5
libmambapy                    1.4.2
libneuronxla                  0.5.971
lockfile                      0.12.2
mamba                         1.4.2
markdown-it-py                3.0.0
MarkupSafe                    2.1.5
matplotlib                    3.8.4
matplotlib-inline             0.1.6
mdurl                         0.1.2
mpmath                        1.3.0
multidict                     6.0.5
multiprocess                  0.70.16
networkx                      2.6.3
neuronx-cc                    2.13.66.0+6dfecc895
neuronx-distributed           0.7.0
neuronx-hwm                   2.12.0.0+422c9037c
numpy                         1.24.4
nvidia-cublas-cu11            11.10.3.66
nvidia-cuda-nvrtc-cu11        11.7.99
nvidia-cuda-runtime-cu11      11.7.99
nvidia-cudnn-cu11             8.5.0.96
oauth2client                  4.1.3
opencv-python                 4.9.0.80
optimum                       1.18.1
optimum-neuron                0.0.21
orjson                        3.10.1
packaging                     23.2
pandas                        1.5.3
parso                         0.8.3
pexpect                       4.9.0
pgzip                         0.3.5
pillow                        10.2.0
pip                           24.0
pluggy                        1.4.0
prompt-toolkit                3.0.43
protobuf                      3.19.6
psutil                        5.9.5
ptyprocess                    0.7.0
pure-eval                     0.2.2
pyarrow                       16.0.0
pyarrow-hotfix                0.6
pyasn1                        0.5.1
pyasn1-modules                0.3.0
pycosat                       0.6.6
pycparser                     2.21
pydantic                      2.7.1
pydantic_core                 2.18.2
pydub                         0.25.1
Pygments                      2.17.2
pyOpenSSL                     24.0.0
pyparsing                     3.1.1
PySocks                       1.7.1
python-daemon                 3.0.1
python-dateutil               2.8.2
python-dotenv                 1.0.1
python-multipart              0.0.9
pytz                          2024.1
PyYAML                        6.0.1
referencing                   0.35.0
regex                         2023.12.25
requests                      2.31.0
requests-unixsocket           0.3.0
retrying                      1.3.4
rich                          13.7.1
rpds-py                       0.18.0
rsa                           4.7.2
ruamel.yaml                   0.17.40
ruamel.yaml.clib              0.2.8
ruff                          0.4.2
s3transfer                    0.10.1
safetensors                   0.4.2
sagemaker_pytorch_inference   2.0.21
scikit-learn                  1.4.1.post1
scipy                         1.10.1
semantic-version              2.10.0
sentencepiece                 0.2.0
setuptools                    69.1.1
shellingham                   1.5.4
six                           1.16.0
sniffio                       1.3.1
stack-data                    0.6.3
starlette                     0.37.2
sympy                         1.12
threadpoolctl                 3.3.0
tokenizers                    0.15.2
tomlkit                       0.12.0
toolz                         0.12.1
torch                         1.13.1
torch-model-archiver          0.9.0
torch-neuronx                 1.13.1.1.14.0
torch-xla                     1.13.1+torchneurone
torchserve                    0.9.0
torchvision                   0.14.1
tqdm                          4.66.2
traitlets                     5.14.1
transformers                  4.36.2
transformers-neuronx          0.10.0.21
typer                         0.12.3
typing_extensions             4.10.0
uritemplate                   3.0.1
urllib3                       2.0.7
uvicorn                       0.29.0
uvloop                        0.19.0
watchfiles                    0.21.0
wcwidth                       0.2.13
websockets                    11.0.3
wget                          3.2
wheel                         0.42.0
xxhash                        3.4.1
yarl                          1.9.4
zipp                          3.18.1
zstandard                     0.22.0
```

Training tutorial:
Convergence graph for training tutorials
Performance metrics average_throughput, latency_p50, latency_p99 and MFU% if available


Please make sure this PR contains correct classification terms (Alpha, Beta, and Stable).

If possible, provide your results or a link to them for the reviewer to check your work.


*Issue #, sim, or t.corp if available:*


*Link to RTD for my changes:* 
https://awsdocs-neuron-staging.readthedocs-hosted.com/en/YOUR_BRANCH_NAME/


*Additional context:*





## PR Checklist
- [ x] I've completely filled out the form above!
- [x ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [ x] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ x] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
