### PR TITLE
docs: add copybutton

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -81,6 +81,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'local_documenter',
     'archive',
+    "sphinx_copybutton",
 ]
 
 
@@ -96,6 +97,10 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build','**.ipynb_checkpoints','.venv']
 html_extra_path = ['static']
+
+# remove bash/python/ipython/jupyter prompts and continuations
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # nbsphinx_allow_errors = True
 nbsphinx_execute = 'never'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ sphinx-panels==0.6.0
 sphinx-rtd-theme==0.5.2
 sphinx-tabs==3.2.0
 sphinx_design==0.3.0
+sphinx-copybutton==0.5.2
 sphinxcontrib-ansi
 sphinxcontrib-applehelp
 sphinxcontrib-contentui==0.2.5


### PR DESCRIPTION
*Description:*

This is a docs-only change that adds `Copy to Clipboard` button like so:

<img width="822" alt="image" src="https://github.com/aws-neuron/aws-neuron-sdk/assets/379115/5790ea32-7707-41a4-a27d-be67f5a17614">

**MANDATORY: PR needs test run output**

**Test Run Output:**
Please specify the release version, instance size and type, OS type and test output.

Training tutorial:
Convergence graph for training tutorials
Performance metrics average_throughput, latency_p50, latency_p99 and MFU% if available


Please make sure this PR contains correct classification terms (Alpha, Beta, and Stable).

If possible, provide your results or a link to them for the reviewer to check your work.


*Issue #, sim, or t.corp if available:*


*Link to RTD for my changes:* 
https://awsdocs-neuron-staging.readthedocs-hosted.com/en/YOUR_BRANCH_NAME/


*Additional context:*





## PR Checklist
- [ ] I've completely filled out the form above!
- [ ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [x] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ ] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
