### PR TITLE
Update docs mentioning deprecated `aws.amazon.com/neurondevice` resource

### DIFF
--- a/containers/tutorials/build-run-neuron-container.rst
+++ b/containers/tutorials/build-run-neuron-container.rst
@@ -82,13 +82,13 @@ Devices
         docker run -e “AWS_NEURON_VISIBLE_DEVICES=0,1”
         docker run -e “AWS_NEURON_VISIBLE_DEVICES=ALL”
 
-- In kubernetes environment, the neuron device plugin is used for exposing the neuron device to the containers in the pod. The number of devices can be adjusted using the *aws.amazon.com/neurondevice* resource in the pod specification. Refer :ref:`K8s setup <tutorial-k8s-env-setup-for-neuron>` for more details
+- In kubernetes environment, the neuron device plugin is used for exposing the neuron device to the containers in the pod. The number of devices can be adjusted using the *aws.amazon.com/neuron* resource in the pod specification. Refer :ref:`K8s setup <tutorial-k8s-env-setup-for-neuron>` for more details
 
     .. code:: bash
 
          resources:
             limits:
-            aws.amazon.com/neurondevice: 1
+            aws.amazon.com/neuron: 1
 
    .. note::
 


### PR DESCRIPTION
*Description:*
Update docs mentioning deprecated `aws.amazon.com/neurondevice` resource after https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/announcements/neuron2.x/announce-no-support-device-version.html


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
