### PR TITLE
NEURON_RT_VISIBLE_CORES can be comma-separated NeuronCores

### DIFF
--- a/neuron-runtime/nrt-configurable-parameters.rst
+++ b/neuron-runtime/nrt-configurable-parameters.rst
@@ -23,7 +23,7 @@ configure NeuronX Runtime behavior.
      - RT Version
    * - ``NEURON_RT_VISIBLE_CORES``
      - Range of specific NeuronCores needed by the process
-     - Integer range (like 1-3)
+     - Integer range (like 1-3), a comma-separated list (like 3,1,2), or both (like 2-3,1)
      - Any value or range between 0 to Max NeuronCore in the system.
      - None
      - 2.0+


### PR DESCRIPTION
Since 2.16.18.0, NEURON_RT_VISIBLE_CORES can now be a comma-separated list of individual NeuronCores and/or ranges of NeuronCores

**MANDATORY: PR needs test run output**

**Test Run Output:**
Documentation change only

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
