### PR TITLE
Dead link in training-troubleshooting.rst

### DIFF
--- a/frameworks/torch/torch-neuronx/training-troubleshooting.rst
+++ b/frameworks/torch/torch-neuronx/training-troubleshooting.rst
@@ -20,7 +20,7 @@ For setting up EFA that is needed for multi-node training, please see :ref:`setu
 For XLA-related troubleshooting notes see :ref:`How to debug models in PyTorch
 Neuron <pytorch-neuronx-debug>`
 and `PyTorch-XLA troubleshooting
-guide <https://github.com/pytorch/xla/blob/master/TROUBLESHOOTING.md>`__.
+guide <https://github.com/pytorch/xla/blob/v1.10.0/TROUBLESHOOTING.md>`__.
 
 If your multi-worker training run is interrupted, you may need to kill
 all the python processes (WARNING: this kills all python processes and


### PR DESCRIPTION
Doc only change

Added link to a specific version to match https://github.com/aws-neuron/aws-neuron-sdk/blob/e6832861f084a9e71532a4c7b8d6cfa5e9be5b0c/frameworks/torch/torch-neuronx/api-reference-guide/training/torch-neuron-envvars.rst#L157  and
https://github.com/aws-neuron/aws-neuron-sdk/blob/e6832861f084a9e71532a4c7b8d6cfa5e9be5b0c/conf.py#L300

Alternatively, you could update all the links to point to the new location in the master:  https://github.com/pytorch/xla/blob/master/docs/source/learn/troubleshoot.md






## PR Checklist
- [x ] I've completely filled out the form above!
- [ ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [ ] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ ] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
