### PR TITLE
Update and extend envvars's RST with XLA_USE_32BIT_LONG

### DIFF
--- a/frameworks/torch/torch-neuronx/api-reference-guide/training/torch-neuron-envvars.rst
+++ b/frameworks/torch/torch-neuronx/api-reference-guide/training/torch-neuron-envvars.rst
@@ -155,6 +155,11 @@ PyTorch Neuron are (beta ones are noted):
 - Integer range of specific NeuronCores needed by the process (for example, 0-3 specifies NeuronCores 0, 1, 2, and 3).
   You this environment variable when using torchrun to limit the launched processs to specific consecutive NeuronCores. To ensure best performance, the multi-core jobs requiring N NeuronCores for collective communication must be placed at the NeuronCore ID that starts at a multiple of N, where N is the world size limited to 1, 2, 8, 32. For example, a process using 2 NeuronCores can be mapped to 2 free NeuronCores starting at NeuronCore id 0, 2, 4, 6, etc, and a process using 8 NeuronCores can be mapped to 8 free NeuronCores starting at NeuronCore id 0, 8, 16, 24.
 
+``XLA_USE_32BIT_LONG`` **[PyTorch XLA 2.6+]**
+
+- Sets the default type for XLA IRs to 32-bits for signed and unsigned 64-bit integers. This will ensure that PyTorch XLA will generate 32-bit instructions, implicitly downcasting any 64-bit integers. This is particularly helpful to bypass known Neuron compiler limitations with 64-bits.
+  Note that the PyTorch operations with 64-bit integers that can not be safely converted to 32-bits will fail during PyTorch XLA's lowering.
+
 Additional Neuron runtime environment variables are described in `runtime
 configuration
 documentation <https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-guide/neuron-runtime/nrt-configurable-parameters.html>`__.

--- a/frameworks/torch/torch-neuronx/api-reference-guide/training/torch-neuron-envvars.rst
+++ b/frameworks/torch/torch-neuronx/api-reference-guide/training/torch-neuron-envvars.rst
@@ -152,7 +152,7 @@ PyTorch Neuron are (beta ones are noted):
 
 ``NEURON_RT_VISIBLE_CORES`` **[Neuron Runtime]**
 
-  Integer range of specific NeuronCores needed by the process (for example, 0-3 specifies NeuronCores 0, 1, 2, and 3).
+- Integer range of specific NeuronCores needed by the process (for example, 0-3 specifies NeuronCores 0, 1, 2, and 3).
   You this environment variable when using torchrun to limit the launched processs to specific consecutive NeuronCores. To ensure best performance, the multi-core jobs requiring N NeuronCores for collective communication must be placed at the NeuronCore ID that starts at a multiple of N, where N is the world size limited to 1, 2, 8, 32. For example, a process using 2 NeuronCores can be mapped to 2 free NeuronCores starting at NeuronCore id 0, 2, 4, 6, etc, and a process using 8 NeuronCores can be mapped to 8 free NeuronCores starting at NeuronCore id 0, 8, 16, 24.
 
 Additional Neuron runtime environment variables are described in `runtime


### PR DESCRIPTION
*Description:*

This PR fixes one itemization and introduces XLA_USE_32BIT_LONG to the envvars RST.

**MANDATORY: PR needs test run output**

**Test Run Output:**
N/A

Training tutorial: N/A



*Link to RTD for my changes:* 
 https://awsdocs-neuron-staging.readthedocs-hosted.com/en/YOUR_BRANCH_NAME/


## PR Checklist
- [x] I've completely filled out the form above!
- [ ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [ ] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ ] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
