### PR TITLE
fixing links in locate-neuron-dlc-image.rst

### DIFF
--- a/containers/locate-neuron-dlc-image.rst
+++ b/containers/locate-neuron-dlc-image.rst
@@ -44,8 +44,8 @@ Inference Containers
       -
 
     * - HuggingFace Inference Containers
-      - | `HuggingFace Text Generation Inference (TGI) Containers <https:https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-text-generation-inference-tgi-containers>`_
-        | `HuggingFace Neuron Inference Containers <https:https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-inference-containers>`_
+      - | `HuggingFace Text Generation Inference (TGI) Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-text-generation-inference-tgi-containers>`_
+        | `HuggingFace Neuron Inference Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-inference-containers>`_
       -
 
     * - Triton Inference Containers
@@ -71,7 +71,7 @@ Training Containers
       - :ref:`tutorial-training`
 
     * - HuggingFace Training Containers
-      - `HuggingFace Neuron Training Containers <https:https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-training-containers>`_
+      - `HuggingFace Neuron Training Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-training-containers>`_
       -
 
 


### PR DESCRIPTION
Apparently, too much https is a bad thing.

This is a doc only change to fix the links.

*Additional context:*





## PR Checklist
- [kind of ] I've completely filled out the form above!
- [ ] (If applicable) I've automated a test to safegaurd my changes from regression.
- [ ] (If applicable) I've posted test collateral to prove my change was effective and not harmful.
- [ ] (If applicable) I've added someone from QA to the list of reviewers.  Do this if you didn't make an automated test or feel it's appropriate for another reason.
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the pre-approved Amazon license list.  See https://inside.amazon.com/en/services/legal/us/OpenSource/Pages/BlessedOpenSourceLicenses.aspx.


## Pytest Marker Checklist
(Coming soon...)


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the changes render correctly on RTD (link above)
- [ ] I've ensured the submitter completed the form 
- [ ] (If appropriate) I've run tests to verify the contents of the change


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
