### PR TITLE
[IMPORTANT: Cannot support 64-bit custom ops generically]

### DIFF
--- a/neuron-customops/api-reference-guide/custom-ops-ref-guide.rst
+++ b/neuron-customops/api-reference-guide/custom-ops-ref-guide.rst
@@ -38,7 +38,6 @@ The following dtypes are supported:
 * torch::kHalf
 * torch::kInt
 * torch::kChar
-* torch::kLong
 * torch::kShort
 * torch::kByte
 


### PR DESCRIPTION
We must remove torch::kLong from the supported dtypes since we are unable to support 64-bit custom ops.
Please remove ASAP.

Thank you