### PR TITLE
Update matrix_multiplication_nki_kernels.py

### DIFF
--- a/general/nki/examples/matrix_multiplication/matrix_multiplication_nki_kernels.py
+++ b/general/nki/examples/matrix_multiplication/matrix_multiplication_nki_kernels.py
@@ -376,9 +376,9 @@ def nki_matmul_fully_optimized_(
     # Copying the result from SBUF to HBM
     for m in nl.affine_range(NUM_BLOCK_M):
       for bm in nl.affine_range(TILES_IN_BLOCK_M):
-        i_res = nl.mgrid[0:TILE_K, 0:TILE_N]
-        i_res_packed = nl.mgrid[0:TILE_K, 0:BLOCK_N]
-        result_packed = nl.ndarray((TILE_K, BLOCK_N),
+        i_res = nl.mgrid[0:TILE_M, 0:TILE_N]
+        i_res_packed = nl.mgrid[0:TILE_M, 0:BLOCK_N]
+        result_packed = nl.ndarray((TILE_M, BLOCK_N),
                                    dtype=result_tiles.dtype,
                                    buffer=nl.sbuf)
 
@@ -388,7 +388,7 @@ def nki_matmul_fully_optimized_(
                         bn * TILE_N + i_res.x] = nl.copy(result_tiles[m, bm, bn,
                                                                       i_res.p,
                                                                       i_res.x])
-        nl.store(result[(TILES_IN_BLOCK_M * m + bm) * TILE_K + i_res_packed.p,
+        nl.store(result[(TILES_IN_BLOCK_M * m + bm) * TILE_M + i_res_packed.p,
                         BLOCK_N * n + i_res_packed.x],
                  value=result_packed[i_res_packed.p, i_res_packed.x])
 


### PR DESCRIPTION



> **AWS email alias**: zolcsaki}@amazon.com

>**Description**
Line 103 of nki_matmul_fully_optimized_ (https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/tutorials/matrix_multiplication.html#:~:text=i_res%20%3D%20nl.mgrid%5B0%3ATILE_K%2C%200%3ATILE_N%5D%0A104)

should be

i_res = nl.mgrid[0:TILE_M, 0:TILE_N]

Same with lines lines 104,105, 115 replace TILE_K with TILE_M.

This does not fail out because TILE_K==TILE_M in this case, but if you change the tile sizes to be different it will make the code wrong.


