### PR TITLE
Fix off-by-one in NKI tensor indexing example comment

### DIFF
--- a/nki/get-started/nki-language-guide.rst
+++ b/nki/get-started/nki-language-guide.rst
@@ -290,7 +290,7 @@ We can refer to specific elements of the tensor using an index expression.
 
 .. code-block:: python
 
-   # 10th element in partition 0
+   # 11th element in partition 0
    u = t[0,0,10]
 
    # 65th element in partition 0


### PR DESCRIPTION
The comment for `u = t[0,0,10]` said "10th element in partition 0", but the index 10 with 0-based indexing refers to the 11th element. The next example in the same section (`t[0,1,0]`) is correctly described as the "65th element", so this change makes the two consistent.

**IMPORTANT!** _If this is a documentation PR for a specific release, this PR must go the corresponding release branch_ (`release-X.XX.X`). _If it is an "out-of-band" doc update, the PR must go to the_ `master` _branch_.


## Required PR information

> **AWS email alias**: qharrisp@amazon.com

>**Description**: Fix off-by-one in the comment for `u = t[0, 0, 10]` in the NKI language guide's "Tensor Indexing" section. The comment said "10th element in partition 0", but with 0-based indexing the index 10 refers to the 11th element. This makes the comment consistent with the adjacent example `u = t[0, 1, 0]`, which is correctly described as the "65th element". No corresponding Jira ticket — out-of-band doc fix spotted while reading the guide.

> **Date this must be published by**: No specific deadline — out-of-band fix, can ship with any release.

> **Link to ReadTheDocs staging for this branch's doc changes**:https://awsdocs-neuron-staging.readthedocs-hosted.com/en/patch-1/ (Note: I receive a 403 on the staging site as an external contributor. Reviewers with access can verify the rendered change there.)

> **Set the `docs-review-needed` label on the PR for tracking.**

## Trivial change

Per the template's note: "For trivial changes, you only need @erickson-doug's approval. He will merge your content once he's confirmed the fixes on staging." Requesting only @erickson-doug as reviewer.

### Engineering reviewer checklist

- [x] I've confirmed that the contributions in this PR meet the current  [AWS Neuron writing guidelines](https://quip-amazon.com/m97CAO0kQFEU/Writing-for-AWS-Neuron).
- [x] I've confirmed that the documentation submitted is technically correct to the best of my knowledge.
- [x] I've confirmed that the documentation submitted has no spelling or grammar errors or use of internal jargon/terminology.
- [x] I've verified the changes render correctly on RTD (link above).
- [x] (If code is included) I've run tests to verify the contents of the change.

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.