### PR TITLE
Fix index order in tiled matmul pseudo-code (LHS_T is shape [K, M])

### DIFF
--- a/nki/guides/tutorials/matrix_multiplication.rst
+++ b/nki/guides/tutorials/matrix_multiplication.rst
@@ -101,7 +101,7 @@ to LHS_T (``[K,M]``) for optimal performance of the underlying TensorE.
        accum = zeros((128, 512))
        # Tile contraction dimension
        for k in range(0, K, 128):
-         lhsT_tile = LHS_T[m : m+128, k : k+128]
+         lhsT_tile = LHS_T[k : k+128, m : m+128]
          rhs_tile = RHS[k : k+128, n : n+512]
          accum += dot(lhsT_tile, rhs_tile)
        RES[m : m+128, n : n+512] = accum


### PR DESCRIPTION
The pseudo-code for tiling an [M,K] @ [K,N] matmul slices LHS_T as `LHS_T[m:m+128, k:k+128]`, but the surrounding text states that LHS_T has shape [K, M] (the transpose of LHS, with K as the first dimension). With shape [K, M], the slice should index K first and M second: `LHS_T[k:k+128, m:m+128]`.

This makes the slice consistent with:
- The stated LHS_T shape in the comments above the loop
- The rhs_tile slice on the next line, which correctly indexes K first
- The actual NKI matmul kernels later in the same guide, which all index LHS_T as `[k:k+TILE_K, m:m+TILE_M]`

**IMPORTANT!** _If this is a documentation PR for a specific release, this PR must go the corresponding release branch_ (`release-X.XX.X`). _If it is an "out-of-band" doc update, the PR must go to the_ `master` _branch_.


## Required PR information

To expedite approvals and merges for releases, provide the following information (select the `...` button to the right at the top of your PR message to edit it):

> **AWS email alias**: qharrisp@amazon.com

>**Description**: The pseudo-code for tiling an [M,K] @ [K,N] matmul slices LHS_T as `LHS_T[m:m+128, k:k+128]`, but the surrounding text states that LHS_T has shape [K, M] (the transpose of LHS, with K as the first dimension). With shape [K, M], the slice should index K first and M second: `LHS_T[k:k+128, m:m+128]`. No corresponding Jira ticket — out-of-band doc fix spotted while reading the guide.

> **Date this must be published by**: No specific deadline — out-of-band fix, can ship with any release.

> **Link to ReadTheDocs staging for this branch's doc changes**: https://awsdocs-neuron-staging.readthedocs-hosted.com/en/patch-2/ (Note: I receive a 403 on the staging site as an external contributor. Reviewers with access can verify the rendered change there.)

> **Set the `docs-review-needed` label on the PR for tracking.**

## Trivial change

Per the template's note: "For trivial changes, you only need @erickson-doug's approval. He will merge your content once he's confirmed the fixes on staging." Requesting only @erickson-doug as reviewer.

### Engineering reviewer checklist

- [x] I've confirmed that the contributions in this PR meet the current  [AWS Neuron writing guidelines](https://quip-amazon.com/m97CAO0kQFEU/Writing-for-AWS-Neuron).
- [x] I've confirmed that the documentation submitted is technically correct to the best of my knowledge.
- [x] I've confirmed that the documentation submitted has no spelling or grammar errors or use of internal jargon/terminology.
- [x] I've verified the changes render correctly on RTD (link above).
- [x] (If code is included) I've run tests to verify the contents of the change.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.