### PR TITLE
fix: Add 'ignore' oob_mode for sentinel index fill/drop semantics (closes #1335)

### DIFF
--- a/nki/api/nki/isa/__init__.py
+++ b/nki/api/nki/isa/__init__.py
@@ -78,6 +78,9 @@ class oob_mode(Enum):
     skip = ...
     r"""Silently skip the runtime out-of-bounds access."""
 
+    ignore = ...
+    r"""Completely ignore out-of-bounds indices; no memory access occurs (used for max-int sentinel fill/drop semantics)."""
+
     ...
 
 class matmul_perf_mode(Enum):


### PR DESCRIPTION
## What
JAX indexed fill/drop operations using max-int sentinels can trigger NRT_EXEC_OOB because the hardware attempts an indirect memory access for the sentinel lane before applying fill/drop semantics. The `oob_mode` enum only had `error` and `skip`, neither of which prevents the actual memory cycle.

## Fix
Add an `ignore` mode to `oob_mode` that instructs the compiler/lower passes to suppress any memory access for out-of-bounds indices (such as max-int sentinels). This allows the fill/drop semantics to be applied without causing spurious OOB errors.

Closes #1335