### PR TITLE
Documentation Update: Refresh Container Image Reference Links and Expand Neuron Explorer Dependency Chain Viewer Guide

### DIFF
--- a/deploy/environments/dlc-images.rst
+++ b/deploy/environments/dlc-images.rst
@@ -46,9 +46,8 @@ Inference Containers
       -
 
     * - HuggingFace Inference Containers
-      - | `HuggingFace Neuron Inference Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-inference-containers>`_
-        | `HuggingFace Neuron vLLM Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-vllm-containers>`_
-        | `HuggingFace Text Generation Inference (TGI) Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-text-generation-inference-tgi-containers>`_
+      - | `HuggingFace PyTorch Inference Neuronx Containers <https://aws.github.io/deep-learning-containers/reference/available_images/#huggingface-pytorch-inference-neuronx>`_
+        | `HuggingFace vLLM Inference Neuronx Containers <https://aws.github.io/deep-learning-containers/reference/available_images/#huggingface-vllm-inference-neuronx>`_
       -
 
     * - Triton Inference Containers
@@ -75,7 +74,7 @@ Training Containers
       - :ref:`tutorial-training`
 
     * - HuggingFace Training Containers
-      - `HuggingFace Neuron Training Containers <https://github.com/aws/deep-learning-containers/blob/master/available_images.md#huggingface-neuron-training-containers>`_
+      - `HuggingFace PyTorch Training Neuronx Containers <https://aws.github.io/deep-learning-containers/reference/available_images/#huggingface-pytorch-training-neuronx>`_
       -
 
 .. note::

--- a/tools/neuron-explorer/overview-system-profiles.rst
+++ b/tools/neuron-explorer/overview-system-profiles.rst
@@ -134,9 +134,14 @@ This will open a new Device Trace Viewer with the selected device profile showin
 Dependency Chain Viewer
 -----------------------
 
-The Dependency Chain Viewer widget enables you to navigate upstream and downstream between related ``neuron_rt`` and ``neuron_hw`` events.
-This helps you correlate runtime and hardware events to identify performance bottlenecks.
-For example, you can select a runtime event and navigate to its related hardware events to understand where time is being spent.
+The Dependency Chain Viewer widget enables you to navigate the dependency chain between system profile events. When you click a system profile event containing a ``flow-id``, the viewer draws arrows indicating the dependency relationship between events. Clicking the event name in the Dependency Chain Viewer triggers the System Trace Viewer to refocus on that specific event.
+For example, you can click a runtime event and navigate to its related hardware events to understand where time is being spent. 
+
+.. note::
+
+   The Dependency Chain Viewer currently displays the dependency chain between framework events (from PyTorch profiler), ``neuron_rt``, and ``neuron_hw`` events. 
+   Native PyTorch profiling is in private beta. You must be enrolled in Native PyTorch private beta 3. Contact the Neuron Product team or see :doc:`/frameworks/torch/pytorch-native-overview` to sign up. For more information, see :doc:`/tools/neuron-explorer/how-to-profile-workload`. 
+
 
 Clicking on an event with dependencies populates the UI with the following elements:
 


### PR DESCRIPTION
## Summary

This documentation update refreshes two pages:

- **Deep learning container reference links** (`deploy/environments/dlc-images.rst`):
  Updated the inference and training container reference links to point to the
  current `aws.github.io/deep-learning-containers/reference/available_images/`
  documentation URLs, replacing the older `available_images.md` anchors.

- **Neuron Explorer — Dependency Chain Viewer** (`tools/neuron-explorer/overview-system-profiles.rst`):
  Expanded the Dependency Chain Viewer section to describe flow-id-based navigation
  between system profile events, and added a note clarifying the framework, runtime,
  and hardware events the viewer supports.

## Changes

- 2 files changed, 11 insertions(+), 7 deletions(-)
- Documentation-only changes; no code or build changes.