### PR TITLE
fix: add sentinel index mask to atomic_rmw example to prevent OOB (closes #1335)

### DIFF
--- a/nki/test/test_nki_nl_atomic_rmw.py
+++ b/nki/test/test_nki_nl_atomic_rmw.py
@@ -46,7 +46,10 @@ def atomic_rmw_indirect_indices(in_tensor, indices_tensor, value_tensor):
   #   - write: saved back into rmw_tensor
   # resulting in rmw_tensor = rmw_tensor + value
   ########################################################################
-  nl.atomic_rmw(rmw_tensor[indices_tile, ix], value=value, op=np.add)
+  # Mask to exclude sentinel indices (e.g., max int) from atomic_rmw
+  sentinel = np.iinfo(indices_tile.dtype).max
+  valid_mask = (indices_tile != sentinel).astype(nl.int1)
+  nl.atomic_rmw(rmw_tensor[indices_tile, ix], value=value, op=np.add, mask=valid_mask)
   # NKI_EXAMPLE_18_END
   return rmw_tensor
 


### PR DESCRIPTION
## What
The test example for atomic_rmw uses indirect indexing via indices_tile. If a user provides a sentinel index equal to the maximum integer value for the dtype, the operation attempts to access memory at that invalid address, causing NRT_EXEC_OOB errors. This is a common pattern in JAX's fill/drop semantics where such sentinels are used to mark inactive lanes.

## Fix
Added a mask that excludes any index equal to the integer maximum (the typical sentinel used in JAX for drop/fill semantics). The nl.atomic_rmw now accepts a `mask` parameter to skip inactive lanes, preventing the out-of-bounds access.

Closes #1335