### PR TITLE
fix: correct JAX and vLLM package version numbers

### DIFF
--- a/about-neuron/whats-new.rst
+++ b/about-neuron/whats-new.rst
@@ -101,7 +101,7 @@ What's in this release
 
 * **Neuron Agentic Development** — `Launched as a beta in April 2026 <https://aws.amazon.com/about-aws/whats-new/2026/04/announcing-neuron-agentic-development/>`_, Neuron Agentic Development adds two new skills in this release: ``neuron-framework-autoport`` ports HuggingFace models to NxD Inference end to end, and ``neuron-framework-equivalence`` validates numerical equivalence of ported models. Both included in all DLAMIs/DLCs by default. See :ref:`agentic-development-2-30-0-rn`.
 
-* **DLAMIs & Containers** — All images now based on Ubuntu 24.04. Upgraded to JAX-NeuronX 0.10.0 (Python 3.13 in JAX SF DLAMI). See :ref:`dlami-2-30-0-rn` and :ref:`containers-2-30-0-rn`.
+* **DLAMIs & Containers** — All images now based on Ubuntu 24.04. See :ref:`dlami-2-30-0-rn` and :ref:`containers-2-30-0-rn`.
 
 
 Software lifecycle updates

--- a/release-notes/components/index.rst
+++ b/release-notes/components/index.rst
@@ -27,13 +27,13 @@ This page provides an index of all Neuron SDK component release notes. Each comp
      - 2.31.0
    * - :doc:`Neuron Developer Tools </release-notes/components/dev-tools>`
      - **2.31.0**
-     - 2.31.11.0
+     - 2.31.13.0
    * - :doc:`Neuron DLAMI </release-notes/components/dlamis>`
      - **2.31.0**
      - 2.31.0
    * - :doc:`JAX NeuronX </release-notes/components/jax>`
      - **2.31.0**
-     - 0.10.0.*
+     - 0.10.0.* (supports up to JAX 0.9.0)
    * - :doc:`NKI Library </release-notes/components/nki-lib>`
      - **2.31.0**
      - 2.31.0
@@ -60,7 +60,7 @@ This page provides an index of all Neuron SDK component release notes. Each comp
      - 2.33.10.0
    * - :doc:`vLLM plugin for Neuron </release-notes/components/nxd-inference>`
      - **2.31.0**
-     - 0.21.0.1.0.0 (supports vLLM version 0.21.0; vllm-neuron version is 1.0.0)
+     - 0.16.0.* (vllm-neuron version is 0.5.0)
 
 * For older components and features that have not been updated recently or are out of support, see :doc:`../archive/index`.
 

--- a/release-notes/index.rst
+++ b/release-notes/index.rst
@@ -65,13 +65,13 @@ Each Neuron component has specific release notes across Neuron versions.
      - 2.31.0
    * - :doc:`Neuron Developer Tools </release-notes/components/dev-tools>`
      - **2.31.0**
-     - 2.31.11.0
+     - 2.31.13.0
    * - :doc:`Neuron DLAMI </release-notes/components/dlamis>`
      - **2.31.0**
      - 2.31.0
    * - :doc:`JAX NeuronX </release-notes/components/jax>`
      - **2.31.0**
-     - 0.10.0.*
+     - 0.10.0.* (supports up to JAX 0.9.0)
    * - :doc:`NKI Library </release-notes/components/nki-lib>`
      - **2.31.0**
      - 2.31.0
@@ -98,7 +98,7 @@ Each Neuron component has specific release notes across Neuron versions.
      - 2.33.10.0
    * - :doc:`vLLM plugin for Neuron </release-notes/components/nxd-inference>`
      - **2.31.0**
-     - 0.21.0.1.0.0 (supports vLLM version 0.21.0; vllm-neuron version is 1.0.0)
+     - 0.16.0.* (vllm-neuron version is 0.5.0)
 
   
 ----


### PR DESCRIPTION
## Summary

Corrects JAX, vLLM, and Neuron Developer Tools package version numbers in the release-notes index pages and the what's-new page.

Changes:
- Neuron Developer Tools: `2.31.11.0` → `2.31.13.0`
- JAX NeuronX: `0.10.0.*` → `0.10.0.* (supports up to JAX 0.9.0)`
- vLLM plugin for Neuron: `0.21.0.1.0.0 (supports vLLM 0.21.0; vllm-neuron 1.0.0)` → `0.16.0.* (vllm-neuron version is 0.5.0)`
- what's-new: removed the stale "Upgraded to JAX-NeuronX 0.10.0 (Python 3.13 in JAX SF DLAMI)" sentence

Files touched:
- `about-neuron/whats-new.rst`
- `release-notes/components/index.rst`
- `release-notes/index.rst`

## Notes

Cherry-picked from internal staging commit `c6f29acd4`.

## Testing

Docs not built locally as part of this change (version-string edits only).
