### PR TITLE
Neuron Explorer and compiler error-code doc updates

### DIFF
--- a/compiler/error-codes/EMOD025.rst
+++ b/compiler/error-codes/EMOD025.rst
@@ -1,0 +1,36 @@
+.. _error-code-emod025:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EMOD025.
+
+NCC_EMOD025
+===========
+
+**Error message**: Dynamic shape is not supported: instruction '<name>' has shape '<shape>'. The Neuron compiler requires all tensor dimensions to be statically sized.
+
+The Neuron compiler requires fully static shapes. This error occurs when the input model contains a tensor whose shape has one or more dynamically-sized dimensions. This includes both unbounded and bounded dynamic dimensions.
+
+Erroneous code example:
+
+.. code-block:: python
+
+    import torch
+
+    class Model(torch.nn.Module):
+        def forward(self, x):
+            return x + x
+
+    model = Model()
+
+    # A dynamic batch dimension produces a dynamically-sized shape, which the
+    # Neuron compiler cannot compile.
+    compiled = torch.compile(model, backend="neuronx", dynamic=True)
+
+To fix this error, recompile the model with fully static input shapes. When compiling via PyTorch ``torch.compile``, set ``dynamic=False`` to disable dynamic shape specialization:
+
+.. code-block:: python
+
+    # Disable dynamic shape specialization so all tensor dimensions are static.
+    compiled = torch.compile(model, backend="neuronx", dynamic=False)
+
+If your model inherently varies an input dimension (for example a variable sequence length), pad or bucket the inputs to a fixed size before compilation so that every tensor dimension is statically known.

--- a/compiler/error-codes/EVRF036.rst
+++ b/compiler/error-codes/EVRF036.rst
@@ -1,0 +1,19 @@
+.. _error-code-evrf036:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF036.
+
+NCC_EVRF036
+===========
+
+**Error message**: QuantizeMX custom call has invalid backend_config JSON.
+
+The ``QuantizeMX`` custom call requires a ``backend_config`` attribute that
+contains valid JSON. The compiler raises this error when the attribute is
+missing or cannot be parsed as JSON.
+
+The ``dim``, ``block_size``, and ``scale_method`` fields are optional and
+default to ``0``, ``32``, and ``"EMAX"``, respectively. A missing or unsupported
+``dtype`` is reported as :ref:`NCC_EVRF042 <error-code-evrf042>`.
+
+To fix this error, provide a valid JSON object in ``backend_config``.

--- a/compiler/error-codes/EVRF037.rst
+++ b/compiler/error-codes/EVRF037.rst
@@ -1,0 +1,16 @@
+.. _error-code-evrf037:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF037.
+
+NCC_EVRF037
+===========
+
+**Error message**: QuantizeMX custom call operand count must be exactly 1 (input tensor).
+
+The ``QuantizeMX`` custom call takes a single input tensor and produces a
+tuple of two outputs (the quantized data and the per-block scale). The
+compiler raises this error when the call has any number of operands other
+than one.
+
+To fix this error, pass exactly one input tensor as the operand.

--- a/compiler/error-codes/EVRF038.rst
+++ b/compiler/error-codes/EVRF038.rst
@@ -1,0 +1,17 @@
+.. _error-code-evrf038:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF038.
+
+NCC_EVRF038
+===========
+
+**Error message**: QuantizeMX custom call dim is invalid for input tensor rank.
+
+The ``dim`` parameter specifies the input dimension to quantize. The compiler
+supports the last dimension for inputs with rank 1 or greater and the
+second-to-last dimension for inputs with rank 2 or greater. Specify the
+dimension as ``-1`` or ``-2``, or use the corresponding non-negative index.
+
+To fix this error, use ``dim=-1`` or ``rank - 1``. For inputs with rank 2 or
+greater, you can also use ``dim=-2`` or ``rank - 2``.

--- a/compiler/error-codes/EVRF039.rst
+++ b/compiler/error-codes/EVRF039.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf039:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF039.
+
+NCC_EVRF039
+===========
+
+**Error message**: QuantizeMX custom call block_size must be 32.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). The OCP MXFP specification requires a block size of 32 elements per scaling factor. The compiler raises this error when a different block_size value is provided in the backend_config.
+
+To fix this error, use ``block_size=32``.

--- a/compiler/error-codes/EVRF040.rst
+++ b/compiler/error-codes/EVRF040.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf040:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF040.
+
+NCC_EVRF040
+===========
+
+**Error message**: QuantizeMX custom call scale_method is unsupported.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). Currently, only the ``"EMAX"`` scale computation method is supported. The compiler raises this error when a different ``scale_method`` value is provided in ``backend_config``.
+
+To fix this error, use ``"scale_method": "EMAX"``.

--- a/compiler/error-codes/EVRF041.rst
+++ b/compiler/error-codes/EVRF041.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf041:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF041.
+
+NCC_EVRF041
+===========
+
+**Error message**: QuantizeMX custom call input type is unsupported.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). Only BF16 and F16 input tensors are supported for quantization. The compiler raises this error when the input tensor has a different element type.
+
+To fix this error, cast the input tensor to BF16 or F16 before quantization.

--- a/compiler/error-codes/EVRF042.rst
+++ b/compiler/error-codes/EVRF042.rst
@@ -1,0 +1,27 @@
+.. _error-code-evrf042:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF042.
+
+NCC_EVRF042
+===========
+
+**Error message**: QuantizeMX custom call is malformed.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf)
+and produces packed FP8 data and block scale factors. The logical FP8 format is
+selected by the ``dtype`` field, but the ``quantized_data`` output is physically
+represented as ``U32``, with four FP8 values packed into each element.
+
+The compiler raises this error when:
+
+1. ``backend_config`` omits ``dtype`` or specifies a value other than
+   ``"float8_e5m2"`` or ``"float8_e4m3fn"``.
+2. The ``quantized_data`` output element type is not ``U32``.
+3. The ``quantized_data`` rank matches the input rank, but a dimension has the
+   wrong size. Each dimension must match the input, except the quantization
+   dimension, which is divided by four for FP8 x4 packing.
+
+To fix this error, use a supported logical ``dtype`` and declare
+``quantized_data`` as a ``U32`` tensor whose shape matches the input except
+that the quantization dimension is one fourth of the input size.

--- a/compiler/error-codes/EVRF043.rst
+++ b/compiler/error-codes/EVRF043.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf043:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF043.
+
+NCC_EVRF043
+===========
+
+**Error message**: ScaledMatmul custom call must have exactly 4 operands.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on MXFP8-quantized tensors produced by ``QuantizeMX``. It requires exactly 4 operands in order: lhs (left-hand side matrix), rhs (right-hand side matrix), lhs_scale (per-block scales for lhs), and rhs_scale (per-block scales for rhs). The compiler raises this error when a different number of operands is provided.
+
+To fix this error, pass all 4 operands (lhs, rhs, lhs_scale, rhs_scale).

--- a/compiler/error-codes/EVRF044.rst
+++ b/compiler/error-codes/EVRF044.rst
@@ -1,0 +1,18 @@
+.. _error-code-evrf044:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF044.
+
+NCC_EVRF044
+===========
+
+**Error message**: ScaledMatmul custom call LHS input type is unsupported.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on
+MXFP8-quantized tensors. The LHS (left-hand side) operand must be a ``U32``
+tensor containing four packed FP8 values per element, as produced by the
+``QuantizeMX`` custom call. The compiler raises this error when the LHS operand
+has a different element type.
+
+To fix this error, use the packed ``U32`` quantized data tensor returned by
+``QuantizeMX`` as the LHS operand.

--- a/compiler/error-codes/EVRF045.rst
+++ b/compiler/error-codes/EVRF045.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf045:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF045.
+
+NCC_EVRF045
+===========
+
+**Error message**: ScaledMatmul custom call output type is unsupported.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on MXFP8-quantized tensors and dequantizes the result. Only F32 and BF16 output types are supported. The compiler raises this error when the result tensor has a different element type.
+
+To fix this error, declare the result as F32 or BF16.

--- a/compiler/error-codes/EVRF046.rst
+++ b/compiler/error-codes/EVRF046.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf046:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF046.
+
+NCC_EVRF046
+===========
+
+**Error message**: ScaledMatmul custom call LHS tensor must have rank >= 2.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on MXFP8-quantized tensors. Matrix operations require at least 2-dimensional tensors (matrices). The LHS (left-hand side) operand must have rank >= 2. The compiler raises this error when the LHS tensor is a scalar or 1-D vector.
+
+To fix this error, reshape the LHS to have at least 2 dimensions.

--- a/compiler/error-codes/EVRF047.rst
+++ b/compiler/error-codes/EVRF047.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf047:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF047.
+
+NCC_EVRF047
+===========
+
+**Error message**: ScaledMatmul custom call RHS tensor must have rank >= 2.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on MXFP8-quantized tensors. Matrix operations require at least 2-dimensional tensors (matrices). The RHS (right-hand side) operand must have rank >= 2. The compiler raises this error when the RHS tensor is a scalar or 1-D vector.
+
+To fix this error, reshape the RHS to have at least 2 dimensions.

--- a/compiler/error-codes/EVRF048.rst
+++ b/compiler/error-codes/EVRF048.rst
@@ -1,0 +1,16 @@
+.. _error-code-evrf048:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF048.
+
+NCC_EVRF048
+===========
+
+**Error message**: ScaledMatmul custom call batch dimension mismatch.
+
+The ``__op$block_scaled_dot`` custom call performs batched matrix multiplication
+on MXFP8-quantized tensors. When the LHS and RHS specify the same number of
+batch dimensions, the compiler compares the products of their batch dimension
+sizes and raises this error if the products differ.
+
+To fix this error, ensure the product of LHS and RHS batch dimension sizes match.

--- a/compiler/error-codes/EVRF049.rst
+++ b/compiler/error-codes/EVRF049.rst
@@ -1,0 +1,29 @@
+.. _error-code-evrf049:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF049.
+
+NCC_EVRF049
+===========
+
+**Error message**: ScaledMatmul custom call could not parse backend_config.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on
+MXFP8-quantized tensors. The compiler accepts an empty ``backend_config``,
+``"None"``, or valid JSON. It raises this error when JSON parsing fails or a
+dimension list contains a value that cannot be converted to an integer.
+
+The ``scaled_dot_backend_config`` object and all of its fields are optional.
+Missing fields use empty values and do not trigger this error. Output dtype is
+determined by the result tensor's element type, not by a JSON field.
+
+The optional fields in ``scaled_dot_backend_config`` with their defaults are:
+
+- ``lhs_batch_dimensions``: array of batch dimension indices for LHS (default ``[]``)
+- ``rhs_batch_dimensions``: array of batch dimension indices for RHS (default ``[]``)
+- ``lhs_contracting_dimensions``: array of contracting dimension indices for LHS (default ``[]``)
+- ``rhs_contracting_dimensions``: array of contracting dimension indices for RHS (default ``[]``)
+- ``element_dtype``: FP8 element dtype ``"float8_e5m2"`` or ``"float8_e4m3fn"`` if specified (default empty string)
+
+To fix this error, provide valid JSON and use integer values in each dimension
+array.

--- a/compiler/error-codes/EVRF050.rst
+++ b/compiler/error-codes/EVRF050.rst
@@ -1,0 +1,16 @@
+.. _error-code-evrf050:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF050.
+
+NCC_EVRF050
+===========
+
+**Error message**: ScaledMatmul custom call contracting dimension sizes mismatch.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on
+MXFP8-quantized tensors. The compiler compares the first configured LHS and RHS
+contracting dimensions and raises this error when their sizes differ. If a
+contracting dimension is omitted, the compiler uses the last dimension.
+
+To fix this error, ensure the LHS and RHS contracting dimension sizes match.

--- a/compiler/error-codes/EVRF051.rst
+++ b/compiler/error-codes/EVRF051.rst
@@ -1,0 +1,24 @@
+.. _error-code-evrf051:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF051.
+
+NCC_EVRF051
+===========
+
+**Error message**: Data type F8E4M3FN is not supported on TRN1/TRN2.
+
+The F8E4M3FN (8-bit floating point with 4-bit exponent and 3-bit mantissa) data
+type is natively supported on Trainium3 (Trn3) and later hardware generations.
+The compiler raises this error for an F8E4M3FN operand targeting Trn1 or Trn2
+unless the experimental F8E4M3 conversion flag is enabled.
+
+For ``QuantizeMX``, the compiler also raises this error when
+``backend_config`` selects ``"float8_e4m3fn"`` and the conversion flag is
+enabled, because MXFP operations do not support conversion to F8E4M3.
+
+To fix this error for ``QuantizeMX``, target Trn3 or later and do not enable
+``--experimental-unsafe-fp8e4m3fn-as-fp8e4m3``. For other operations targeting
+Trn1 or Trn2, the flag can be used to convert F8E4M3FN operands to F8E4M3.
+
+* More information on supported data types: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/arch/neuron-features/data-types.html

--- a/compiler/error-codes/EVRF052.rst
+++ b/compiler/error-codes/EVRF052.rst
@@ -1,0 +1,17 @@
+.. _error-code-evrf052:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF052.
+
+NCC_EVRF052
+===========
+
+**Error message**: Data type F8E4M3 is not supported on hardware newer than Trn3.
+
+The compiler raises this error when an operation has an F8E4M3 operand and
+targets a hardware generation later than Trn3. Later hardware generations
+support the F8E4M3FN format instead.
+
+To fix this error, use F8E4M3FN instead of F8E4M3.
+
+* More information on supported data types: https://awsdocs-neuron.readthedocs-hosted.com/en/latest/about-neuron/arch/neuron-features/data-types.html

--- a/compiler/error-codes/EVRF053.rst
+++ b/compiler/error-codes/EVRF053.rst
@@ -1,0 +1,17 @@
+.. _error-code-evrf053:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF053.
+
+NCC_EVRF053
+===========
+
+**Error message**: ScaledMatmul custom call contracting dimension overlaps with batch dimension.
+
+The ``__op$block_scaled_dot`` custom call performs batched matrix multiplication
+on MXFP8-quantized tensors. Batch dimensions and contracting dimensions must be
+disjoint. The compiler checks the first configured contracting dimension for
+each operand, or the last dimension when none is configured, and raises this
+error when that dimension also appears in the operand's batch dimension list.
+
+To fix this error, ensure batch dimensions and contracting dimensions are disjoint.

--- a/compiler/error-codes/EVRF054.rst
+++ b/compiler/error-codes/EVRF054.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf054:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF054.
+
+NCC_EVRF054
+===========
+
+**Error message**: ScaledMatmul custom call batch dimension index out of bounds.
+
+The ``__op$block_scaled_dot`` custom call performs batched matrix multiplication on MXFP8-quantized tensors. Batch dimension indices specified in the backend_config must be valid (0 <= dim < rank). The compiler raises this error when a batch dimension index is negative or exceeds the tensor rank.
+
+To fix this error, use dimension indices within the valid range (0 <= dim < rank).

--- a/compiler/error-codes/EVRF055.rst
+++ b/compiler/error-codes/EVRF055.rst
@@ -1,0 +1,17 @@
+.. _error-code-evrf055:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF055.
+
+NCC_EVRF055
+===========
+
+**Error message**: ScaledMatmul custom call contracting dimension index out of bounds.
+
+The ``__op$block_scaled_dot`` custom call performs matrix multiplication on
+MXFP8-quantized tensors. The compiler checks the first configured contracting
+dimension for each operand, or the last dimension when none is configured, and
+raises this error when that index is negative or greater than or equal to the
+operand rank.
+
+To fix this error, use dimension indices within the valid range (0 <= dim < rank).

--- a/compiler/error-codes/EVRF057.rst
+++ b/compiler/error-codes/EVRF057.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf057:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF057.
+
+NCC_EVRF057
+===========
+
+**Error message**: QuantizeMX custom call must return a tuple with exactly 2 outputs.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf) and must produce a 2-element tuple: the quantized data tensor and the per-block scale tensor. The compiler raises this error when the result type is not a 2-element tuple.
+
+To fix this error, declare a 2-element tuple result type ``(quantized_data, scale)``.

--- a/compiler/error-codes/EVRF058.rst
+++ b/compiler/error-codes/EVRF058.rst
@@ -1,0 +1,13 @@
+.. _error-code-evrf058:
+
+.. meta::
+   :description: AWS Neuron SDK Graph Compiler error code documentation for error EVRF058.
+
+NCC_EVRF058
+===========
+
+**Error message**: QuantizeMX custom call input dimension must be divisible by 4.
+
+The ``QuantizeMX`` custom call implements OCP MXFP-8 microscaling quantization (https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf). The quantization dimension size must be divisible by 4. The compiler raises this error when the input tensor's quantization dimension size is not a multiple of 4.
+
+To fix this error, pad or reshape the input tensor so the quantization dimension size is a multiple of 4.

--- a/compiler/error-codes/index.rst
+++ b/compiler/error-codes/index.rst
@@ -1,6 +1,6 @@
 .. meta::
     :description: "Neuron Compiler error code documentation home."
-    :date-modified: 12/02/2025
+    :date-modified: 07/14/2026
 
 .. _ncc-errors-home:
 
@@ -27,6 +27,9 @@ This page lists the error codes you can encounter while developing with the Neur
    * - :ref:`NCC_EHCA005 <error-code-ehca005>`
      - The compiler encountered a custom call instruction with a target name that is not recognized.
      - Use a supported custom call target from the list of recognized targets.
+   * - :ref:`NCC_EMOD025 <error-code-emod025>`
+     - Dynamic shape is not supported. The Neuron compiler requires all tensor dimensions to be statically sized.
+     - Recompile the model with fully static input shapes. When compiling via PyTorch torch.compile, set dynamic=False to disable dynamic shape specialization.
    * - :ref:`NCC_EOOM001 <error-code-eoom001>`
      - The combined memory needed for the model's activation tensors exceeds the high-bandwidth memory limit.
      - You may need to reduce batch/tensor size or utilize pipeline/tensor parallelism via neuronx-distributed.
@@ -93,9 +96,75 @@ This page lists the error codes you can encounter while developing with the Neur
    * - :ref:`NCC_EVRF031 <error-code-evrf031>`
      - The compiler encountered a scatter out-of-bounds error.
      - Ensure that the iota size matches the operand dimension size.
+   * - :ref:`NCC_EVRF036 <error-code-evrf036>`
+     - QuantizeMX custom call has invalid backend_config JSON.
+     - Provide a valid JSON object in backend_config.
+   * - :ref:`NCC_EVRF037 <error-code-evrf037>`
+     - QuantizeMX custom call operand count must be exactly 1 (input tensor).
+     - Pass exactly one input tensor as the operand to QuantizeMX.
+   * - :ref:`NCC_EVRF038 <error-code-evrf038>`
+     - QuantizeMX custom call dim is invalid for input tensor rank.
+     - Use the last dimension, or the second-to-last dimension for inputs with rank 2 or greater.
+   * - :ref:`NCC_EVRF039 <error-code-evrf039>`
+     - QuantizeMX custom call block_size must be 32.
+     - Use block_size=32 as required by the OCP MXFP specification.
+   * - :ref:`NCC_EVRF040 <error-code-evrf040>`
+     - QuantizeMX custom call scale_method is unsupported.
+     - Use "EMAX", the only supported scale method.
+   * - :ref:`NCC_EVRF041 <error-code-evrf041>`
+     - QuantizeMX custom call input type is unsupported.
+     - Cast input tensor to BF16 or F16 before quantization.
+   * - :ref:`NCC_EVRF042 <error-code-evrf042>`
+     - QuantizeMX custom call is malformed.
+     - Use a supported logical FP8 dtype and a correctly shaped, U32-packed quantized_data output.
+   * - :ref:`NCC_EVRF043 <error-code-evrf043>`
+     - ScaledMatmul custom call must have exactly 4 operands.
+     - Pass all 4 operands: lhs, rhs, lhs_scale, rhs_scale.
+   * - :ref:`NCC_EVRF044 <error-code-evrf044>`
+     - ScaledMatmul custom call LHS input type is unsupported.
+     - Use the packed U32 quantized data tensor returned by QuantizeMX.
+   * - :ref:`NCC_EVRF045 <error-code-evrf045>`
+     - ScaledMatmul custom call output type is unsupported.
+     - Declare the result as F32 or BF16.
+   * - :ref:`NCC_EVRF046 <error-code-evrf046>`
+     - ScaledMatmul custom call LHS tensor must have rank >= 2.
+     - Reshape the LHS to have at least 2 dimensions.
+   * - :ref:`NCC_EVRF047 <error-code-evrf047>`
+     - ScaledMatmul custom call RHS tensor must have rank >= 2.
+     - Reshape the RHS to have at least 2 dimensions.
+   * - :ref:`NCC_EVRF048 <error-code-evrf048>`
+     - ScaledMatmul custom call batch dimension mismatch.
+     - Ensure the product of LHS and RHS batch dimension sizes match.
+   * - :ref:`NCC_EVRF049 <error-code-evrf049>`
+     - ScaledMatmul custom call could not parse backend_config.
+     - Provide valid JSON with integer values in each dimension array.
+   * - :ref:`NCC_EVRF050 <error-code-evrf050>`
+     - ScaledMatmul custom call contracting dimension sizes mismatch.
+     - Ensure LHS and RHS contracting dimensions have equal size.
+   * - :ref:`NCC_EVRF051 <error-code-evrf051>`
+     - Data type F8E4M3FN is not supported on TRN1/TRN2.
+     - For QuantizeMX, target Trn3 or later without the F8E4M3 conversion flag.
+   * - :ref:`NCC_EVRF052 <error-code-evrf052>`
+     - Data type F8E4M3 is not supported on hardware newer than Trn3.
+     - Use F8E4M3FN instead of F8E4M3.
+   * - :ref:`NCC_EVRF053 <error-code-evrf053>`
+     - ScaledMatmul custom call contracting dimension overlaps with batch dimension.
+     - Ensure batch dimensions and contracting dimensions are disjoint.
+   * - :ref:`NCC_EVRF054 <error-code-evrf054>`
+     - ScaledMatmul custom call batch dimension index out of bounds.
+     - Use dimension indices within valid range (0 <= dim < rank).
+   * - :ref:`NCC_EVRF055 <error-code-evrf055>`
+     - ScaledMatmul custom call contracting dimension index out of bounds.
+     - Use dimension indices within valid range (0 <= dim < rank).
    * - :ref:`NCC_EVRF056 <error-code-evrf056>`
      - Operation gather encountered out of bound indices.
      - Ensure that the iota dimension size is less than or equal to the size of the corresponding operand dimension. Check that your model's max_position_embeddings is >= sequence_length.
+   * - :ref:`NCC_EVRF057 <error-code-evrf057>`
+     - QuantizeMX custom call must return a tuple with exactly 2 outputs.
+     - Declare a 2-element tuple result type (quantized_data, scale).
+   * - :ref:`NCC_EVRF058 <error-code-evrf058>`
+     - QuantizeMX custom call input dimension must be divisible by 4.
+     - Pad or reshape the input so the quantization dimension size is a multiple of 4.
    * - :ref:`NCC_EVRF059 <error-code-evrf059>`
      - Kernel file referenced by AwsNeuronCustomNativeKernel instruction does not exist on the host.
      - Ensure the NKI kernel artifact file exists at the specified path before compilation. Clear the NKI file cache and retrace the model, or copy artifacts into the compiler launch directory.
@@ -114,6 +183,7 @@ This page lists the error codes you can encounter while developing with the Neur
     EBIR023
     EBVF030
     EHCA005
+    EMOD025
     EOOM001
     EOOM002
     ESFH002
@@ -136,7 +206,29 @@ This page lists the error codes you can encounter while developing with the Neur
     EVRF019
     EVRF022
     EVRF031
+    EVRF036
+    EVRF037
+    EVRF038
+    EVRF039
+    EVRF040
+    EVRF041
+    EVRF042
+    EVRF043
+    EVRF044
+    EVRF045
+    EVRF046
+    EVRF047
+    EVRF048
+    EVRF049
+    EVRF050
+    EVRF051
+    EVRF052
+    EVRF053
+    EVRF054
+    EVRF055
     EVRF056
+    EVRF057
+    EVRF058
     EVRF059
     EXSP001
     EXTP004

--- a/release-notes/components/dev-tools.rst
+++ b/release-notes/components/dev-tools.rst
@@ -1,7 +1,7 @@
 .. meta::
     :description: Complete release notes for the Neuron Developer Tools component across all AWS Neuron SDK versions.
     :keywords: neuron tools, developer tools, profiler, release notes, neuron explorer, aws neuron sdk
-    :date-modified: 05/21/2026
+    :date-modified: 07/14/2026
 
 .. _dev-tools_rn:
 
@@ -21,14 +21,17 @@ Date of Release: 07/07/2026
 Improvements
 ~~~~~~~~~~~~~~~
 
+* Added PyTorch native profiling support in Neuron Explorer, enabling profiling of ``torch.compile`` and eager mode workloads with differences in NEFF generation between the two modes. See :doc:`/tools/neuron-explorer/how-to-profile-workload`.
+* Enhanced the System Trace Viewer with source code linking for PyTorch profiles, enabling navigation from trace events to corresponding source code. See :doc:`/tools/neuron-explorer/overview-system-profiles` and :doc:`/tools/neuron-explorer/how-to-link-view-source-code`.
+* Updated the default grouping mode in the System Trace Viewer to organize events by instance ID, process ID, and event source, with sub-grouping by thread ID for framework dispatch events, stream ID for device interaction events, Logical NeuronCore for runtime events, and physical NeuronCore for hardware events. See :doc:`/tools/neuron-explorer/overview-system-profiles`.
+* Added Profile Comparison (beta) to Neuron Explorer, enabling side-by-side comparison of two or more device profiles to identify performance differences between runs. See :ref:`profile-comparison`.
+* Added light mode support in Neuron Explorer, accessible through the Dark/Light Mode Toggle button. See :ref:`neuron-explorer-dark-light-mode`.
+* Updated ``nccom-test`` collective op latency values from integer to floating point values, providing more accurate latency measurement. Due to previous integer truncation, new floating point latency results may increase slightly (~0.5 us) for some operations.
+* Added profile schema reference page documenting all Neuron Explorer parquet output tables and enums, including field names, types, units, and descriptions, enabling users to reference the output schema without requiring CLI access. See :doc:`/tools/neuron-explorer/profile-schema-reference`.
 * Added UI overview tour page for Neuron Explorer, providing a guided walkthrough of all viewers and tools grouped by workflow, a clickable UI navigation map, and support for light and dark mode. See :doc:`/tools/neuron-explorer/overview-ui-tour`.
 * Added environment variables reference documenting all variables for Neuron Explorer profiling, capture, debug, filtering, and runtime configuration, including recommended combinations for common scenarios (system-only, full debug, vLLM/inference, distributed). See :doc:`/tools/neuron-explorer/environment-variables`.
 * Added troubleshooting guide and FAQ for Neuron Explorer covering error codes, processing failures, capture issues, missing data diagnosis, performance issues, and timing/measurement. See :doc:`/tools/neuron-explorer/troubleshooting`.
 * Standardized Neuron Explorer terminology across documentation and added a glossary covering viewers, profile types, UI components, and Neuron-specific acronyms. See :doc:`/tools/neuron-explorer/glossary`.
-* Enhanced the System Trace Viewer with source code linking for navigating from trace events to corresponding source code, and updated the default grouping mode to organize events by instance ID, process ID, and event source, with sub-grouping by thread ID for framework dispatch events, stream ID for device interaction events, Logical NeuronCore for runtime events, and physical NeuronCore for hardware events. See :doc:`/tools/neuron-explorer/overview-system-profiles`.
-* Documented ``torch.compile`` and eager mode profiling support in Neuron Explorer, clarifying differences in NEFF generation between the two modes. See :doc:`/tools/neuron-explorer/how-to-profile-workload`.
-* Added profile schema reference page documenting all Neuron Explorer parquet output tables and enums, including field names, types, units, and descriptions, enabling users to reference the output schema without requiring CLI access. See :doc:`/tools/neuron-explorer/profile-schema-reference`.
-* Updated ``nccom-test`` collective op latency values from integer to floating point values, providing more accurate latency measurement. Due to previous integer truncation, new floating point latency results may increase slightly (~0.5 us) for some operations.
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~

--- a/tools/neuron-explorer/overview-device-profiles.rst
+++ b/tools/neuron-explorer/overview-device-profiles.rst
@@ -1,6 +1,6 @@
 .. meta::
     :description: Learn about Neuron Explorer widgets for device profiling including timeline views, event details, annotations, and performance analysis tools.
-    :date-modified: 06/26/2026
+    :date-modified: 07/13/2026
 
 Device Trace Viewer
 ===================
@@ -138,8 +138,15 @@ Understanding and optimizing performance with the profiler can be overwhelming g
 
 .. image:: /tools/images/device-profile-13.png
 
-Profile Comparison
-~~~~~~~~~~~~~~~~~~
+.. _profile-comparison:
+
+Profile Comparison (beta)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   Profile Comparison is a beta feature in this release. The interface and
+   behavior might change in future releases based on user feedback.
 
 Profile Comparison lets you view two or more device profiles side by side to identify performance differences between runs — for example, before and after an optimization, across different compiler flags, or between model variants.
 

--- a/tools/neuron-explorer/overview-ui-tour.rst
+++ b/tools/neuron-explorer/overview-ui-tour.rst
@@ -1,7 +1,7 @@
 .. meta::
     :description: Guided overview of the Neuron Explorer UI — every viewer and tool grouped by use case with screenshots and descriptions.
     :keywords: neuron explorer, profiling, UI overview, performance analysis, debugging, memory, timeline, NKI, Trainium
-    :date-modified: 2026-06-22
+    :date-modified: 2026-07-13
 
 .. _neuron-explorer-ui-tour:
 
@@ -297,6 +297,8 @@ dropdown to switch profiles within any widget.
 
 **When to use:** Compare execution across NeuronCores or instances in a distributed
 workload.
+
+.. _neuron-explorer-dark-light-mode:
 
 Dark and light mode
 ~~~~~~~~~~~~~~~~~~~

--- a/tools/neuron-explorer/profile-schema-reference.rst
+++ b/tools/neuron-explorer/profile-schema-reference.rst
@@ -10,6 +10,7 @@
 Profile Parquet Schema Reference
 ================================
 
+All of the available Neuron Explorer metrics are viewable as Parquet files.
 When Neuron Explorer processes a profile it writes the results as a set of
 `Parquet <https://parquet.apache.org/>`_ tables (``Summary.parquet``,
 ``Instruction.parquet``, ``DmaPacket.parquet``, and so on). This page documents


### PR DESCRIPTION
Doc-only updates:

- Clarify that all Neuron Explorer metrics are available as Parquet (#3170)
- Add error code for dynamic shapes in input (#3169)
- Add error-code docs for QuantizeMX and ScaledMatmul verifiers (#3171)
- Add (beta) to Profile Comparison and add missing release note entries (#3168)