### PR TITLE
Exclude work-with-neff-files.rst from the documentation build

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -139,7 +139,17 @@ templates_path = [
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', '_backup-rn', '_backup-setup', '_content-types','**.ipynb_checkpoints','.venv','_utilities', 'nki/_templates']
+exclude_patterns = [
+    '_build',
+    '_backup-rn',
+    '_backup-setup',
+    '_content-types',
+    '**.ipynb_checkpoints',
+    '.venv',
+    '_utilities',
+    'nki/_templates',
+    'neuron-runtime/explore/work-with-neff-files.rst',
+]
 html_extra_path = ['static']
 
 # remove bash/python/ipython/jupyter prompts and continuations

--- a/neuron-runtime/explore/index.rst
+++ b/neuron-runtime/explore/index.rst
@@ -11,7 +11,6 @@ Neuron Runtime Deep Dives
    :hidden:
    :maxdepth: 1
 
-   Understand NEFF Files <work-with-neff-files>
    Compute-Communication Overlap <compute-comm-overlap>
    Neuron Device Memory <device-memory>
    Direct HBM Tensor Allocation <direct-hbm-tensor-alloc>
@@ -27,12 +26,6 @@ NeuronX Runtime Deep Dives
 
 .. grid:: 2
         :gutter: 2
-
-        .. grid-item-card:: Understand NEFF Files
-
-                * :ref:`work-with-neff-files`
-
-                Explore the structure and contents of NEFF files, the compiled model format used by the Neuron Runtime.
 
         .. grid-item-card:: Compute-Communication Overlap
 

--- a/static/sitemap1.xml
+++ b/static/sitemap1.xml
@@ -2853,10 +2853,6 @@
     <lastmod>2026-05-08</lastmod>
   </url>
   <url>
-    <loc>https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-runtime/explore/work-with-neff-files.html</loc>
-    <lastmod>2026-05-08</lastmod>
-  </url>
-  <url>
     <loc>https://awsdocs-neuron.readthedocs-hosted.com/en/latest/neuron-runtime/explore/core-dump-deep-dive.html</loc>
     <lastmod>2026-07-17</lastmod>
   </url>

--- a/tools/neuron-explorer/overview-database-viewer.rst
+++ b/tools/neuron-explorer/overview-database-viewer.rst
@@ -8,7 +8,7 @@ Database Viewer
 =====================
 
 The Database Viewer offers an interactive interface providing visibility to all underlying data that the Neuron Explorer
-processes from a :doc:`NEFF </neuron-runtime/explore/work-with-neff-files>` and NTFF. 
+processes from a NEFF and NTFF.
 Use this tool to develop your own analyses, examine profiling data stored in database tables, or run ad-hoc queries during performance analysis. 
 You can access this data through natural language queries or raw SQL.
 


### PR DESCRIPTION
Excludes work-with-neff-files.rst from the Sphinx build and drops the references to it from pages that would otherwise link to a page that no longer builds.

Changes:
- conf.py: add the path to exclude_patterns
- neuron-runtime/explore/index.rst: drop the toctree entry and grid card
- static/sitemap1.xml: drop the URL
- tools/neuron-explorer/overview-database-viewer.rst: replace the :doc: link with plain text